### PR TITLE
G20-390 hypothesis player support

### DIFF
--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -149,9 +149,9 @@ module.exports = class Guest extends Delegator
         this.anchor(annotation)
 
   _addPlayerListener: (crossframe) ->
-    window.addEventListener EVENT_HYPOTHESIS_PATH_CHANGE, @_playerListener, crossframe
+    window.addEventListener EVENT_HYPOTHESIS_PATH_CHANGE, (e) => this._playerListener(crossframe)
 
-  _playerListener: (e, crossframe) =>
+  _playerListener: (crossframe) =>
       this.plugins.Document?.getDocumentMetadata()
       this.getDocumentInfo()
       .then((info) -> crossframe.call('updateFrame', info))

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -149,9 +149,9 @@ module.exports = class Guest extends Delegator
         this.anchor(annotation)
 
   _addPlayerListener: (crossframe) ->
-    window.addEventListener EVENT_HYPOTHESIS_PATH_CHANGE, @_playerListener
+    window.addEventListener EVENT_HYPOTHESIS_PATH_CHANGE, @_playerListener, crossframe
 
-  _playerListener: =>
+  _playerListener: (e, crossframe) =>
       this.plugins.Document?.getDocumentMetadata()
       this.getDocumentInfo()
       .then((info) -> crossframe.call('updateFrame', info))

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -91,6 +91,8 @@ module.exports = class Guest extends Delegator
     this._connectAnnotationSync(@crossframe)
     this._connectAnnotationUISync(@crossframe)
 
+    window.addEventListener 'working', this._playerListener, @crossframe
+
     # Load plugins
     for own name, opts of @options
       if not @plugins[name] and @options.pluginClasses[name]
@@ -145,6 +147,13 @@ module.exports = class Guest extends Delegator
     this.subscribe 'annotationsLoaded', (annotations) =>
       for annotation in annotations
         this.anchor(annotation)
+
+  _playerListener: (crossframe) ->
+    crossframe.on 'getDocumentInfo', (cb) =>
+      this.getDocumentInfo()
+      .then((info) -> alert 'hello')
+      .catch((reason) -> cb(reason))
+      # .then((info) -> crossframe.call('updateFrame', info))
 
   _connectAnnotationUISync: (crossframe) ->
     crossframe.on 'focusAnnotations', (tags=[]) =>

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -72,6 +72,7 @@ module.exports = class Guest extends Delegator
           self._onClearSelection()
 
     this.plugins = {}
+    this._updateListener = {}
     this.anchors = []
 
     # Set the frame identifier if it's available.
@@ -149,13 +150,14 @@ module.exports = class Guest extends Delegator
         this.anchor(annotation)
 
   _addPlayerListener: (crossframe) ->
-    window.addEventListener EVENT_HYPOTHESIS_PATH_CHANGE, (e) => this._playerListener(crossframe)
+    this._updateListener = (e) => this._playerListener(crossframe);
+    window.addEventListener EVENT_HYPOTHESIS_PATH_CHANGE, @_updateListener
 
   _playerListener: (crossframe) =>
       this.plugins.Document?.getDocumentMetadata()
       this.getDocumentInfo()
       .then((info) -> crossframe.call('updateFrame', info))
-      .catch((reason) -> cb(reason))
+      .catch((reason) -> console.error(reason))
 
   _connectAnnotationUISync: (crossframe) ->
     crossframe.on 'focusAnnotations', (tags=[]) =>
@@ -187,7 +189,7 @@ module.exports = class Guest extends Delegator
     $('#annotator-dynamic-style').remove()
 
     this.selections.unsubscribe()
-    window.removeEventListener EVENT_HYPOTHESIS_PATH_CHANGE, @_playerListener
+    window.removeEventListener EVENT_HYPOTHESIS_PATH_CHANGE, @_updateListener
     @adder.remove()
 
     @element.find('.annotator-hl').each ->

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -91,7 +91,7 @@ module.exports = class Guest extends Delegator
     @crossframe.onConnect(=> this._setupInitialState(config))
     this._connectAnnotationSync(@crossframe)
     this._connectAnnotationUISync(@crossframe)
-    this._playerListener(@crossframe)
+    this._addPlayerListener(@crossframe)
 
     # Load plugins
     for own name, opts of @options
@@ -148,8 +148,10 @@ module.exports = class Guest extends Delegator
       for annotation in annotations
         this.anchor(annotation)
 
-  _playerListener: (crossframe) ->
-    window.addEventListener EVENT_HYPOTHESIS_PATH_CHANGE, (e) =>
+  _addPlayerListener: (crossframe) ->
+    window.addEventListener EVENT_HYPOTHESIS_PATH_CHANGE, @_playerListener
+
+  _playerListener: =>
       this.plugins.Document?.getDocumentMetadata()
       this.getDocumentInfo()
       .then((info) -> crossframe.call('updateFrame', info))
@@ -185,7 +187,7 @@ module.exports = class Guest extends Delegator
     $('#annotator-dynamic-style').remove()
 
     this.selections.unsubscribe()
-    window.removeEventListener EVENT_HYPOTHESIS_PATH_CHANGE
+    window.removeEventListener EVENT_HYPOTHESIS_PATH_CHANGE, @_playerListener
     @adder.remove()
 
     @element.find('.annotator-hl').each ->

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -127,7 +127,7 @@ function FrameSync($rootScope, $window, Discovery, store, bridge) {
     });
 
     bridge.on('destroyFrame', destroyFrame.bind(this));
-
+    bridge.on('updateFrame', updateFrame.bind(this));
     // Map of annotation tag to anchoring status
     // ('anchored'|'orphan'|'timeout').
     //
@@ -198,6 +198,10 @@ function FrameSync($rootScope, $window, Discovery, store, bridge) {
         uri: info.uri,
       });
     });
+  }
+
+  function updateFrame({ frameIdentifier, metadata, uri }) {
+    store.updateFrame({ id: frameIdentifier, metadata, uri });
   }
 
   function destroyFrame(frameIdentifier) {

--- a/src/sidebar/store/modules/frames.js
+++ b/src/sidebar/store/modules/frames.js
@@ -13,6 +13,16 @@ const update = {
   CONNECT_FRAME: function (state, action) {
     return {frames: state.frames.concat(action.frame)};
   },
+  UPDATE_FRAME: function (state, { id, metadata, uri }) {
+    return {
+      frames: state.frames.map(frame => {
+        if (frame.id !== id) {
+          return frame;
+        }
+        return Object.assign({}, frame, { id, metadata, uri });
+      }),
+    };
+  },
 
   DESTROY_FRAME: function (state, action) {
     return {
@@ -44,6 +54,13 @@ const actions = util.actionTypes(update);
  */
 function connectFrame(frame) {
   return {type: actions.CONNECT_FRAME, frame: frame};
+}
+
+/**
+ * Update the metadata and/or URI for a frame.
+ */
+function updateFrame({ id, metadata, uri }) {
+  return { type: actions.UPDATE_FRAME, id: id || null, metadata, uri };
 }
 
 /**
@@ -107,6 +124,7 @@ module.exports = {
 
   actions: {
     connectFrame: connectFrame,
+    updateFrame: updateFrame,
     destroyFrame: destroyFrame,
     updateFrameAnnotationFetchStatus: updateFrameAnnotationFetchStatus,
   },


### PR DESCRIPTION
This is the needed patch to trigger a metadata/uri update using an event listener, is just an adaptation of previous PR https://github.com/hypothesis/client/pull/684 done to make hypothesis client refresh and work correctly in SPA.

This does:
- [x] Add the right listener for a custom event that can be dispatched on window global object, catch this event and load new annotations from new metadata/uri. 