### PR TITLE
G20 426 adding document uri to profile and groups

### DIFF
--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -14,7 +14,7 @@ const bridgeEvents = require('../../shared/bridge-events');
  * @param {Profile} profile - The profile object from the API.
  */
 function authStateFromProfile(profile) {
-  if (profile.userid) {
+  if (profile && profile.userid) {
     const parsed = parseAccountID(profile.userid);
     let displayName = parsed.username;
     if (profile.user_info && profile.user_info.display_name) {

--- a/src/sidebar/components/hypothesis-app.js
+++ b/src/sidebar/components/hypothesis-app.js
@@ -72,9 +72,9 @@ function HypothesisAppController(
     self.auth = authStateFromProfile(data.profile);
   });
 
-  session.load().then(profile => {
-    self.auth = authStateFromProfile(profile);
-  });
+  // session.load().then(profile => {
+  //   self.auth = authStateFromProfile(profile);
+  // });
 
   /** Scroll to the view to the element matching the given selector */
   function scrollToView(selector) {

--- a/src/sidebar/components/sidebar-content.js
+++ b/src/sidebar/components/sidebar-content.js
@@ -236,7 +236,6 @@ function SidebarContentController(
   // change.
   $scope.$watch(() => ([
     groups.focused().id,
-    store.profile().userid,
     ...store.searchUris(),
   ]), ([currentGroupId], [prevGroupId]) => {
     // FIXME - There is a bug here where the set of displayed annotations can

--- a/src/sidebar/util/session-util.js
+++ b/src/sidebar/util/session-util.js
@@ -4,7 +4,7 @@
  * Returns true if the sidebar tutorial has to be shown to a user for a given session.
  */
 function shouldShowSidebarTutorial(sessionState) {
-  if (sessionState.preferences.show_sidebar_tutorial) {
+  if (sessionState.preferences && sessionState.preferences.show_sidebar_tutorial) {
     return true;
   }
   return false;

--- a/src/sidebar/util/state-util.js
+++ b/src/sidebar/util/state-util.js
@@ -1,6 +1,23 @@
 'use strict';
 
 /**
+ * Returns the documentFingerprint (DC identifier) when available in the frames state
+ * @param store
+ * @returns {Promise<T>}
+ */
+function getDocumentDCIdentifier(store) {
+  function getIdentifier() {
+    const state = store.getState();
+    const metaFrame = state.frames.find(function (frame) {
+      return frame.metadata && frame.metadata.documentFingerprint;
+    });
+
+    return metaFrame ? metaFrame.metadata.documentFingerprint : null;
+  }
+  return awaitStateChange(store, getIdentifier);
+}
+
+/**
  * Return a value from app state when it meets certain criteria.
  *
  * `await` returns a Promise which resolves when a selector function,
@@ -27,4 +44,4 @@ function awaitStateChange(store, selector) {
   });
 }
 
-module.exports = { awaitStateChange } ;
+module.exports = { awaitStateChange, getDocumentDCIdentifier } ;


### PR DESCRIPTION
Since groups and profile api call is requested before the document metadata has been parsed, I had to add a promise that returned when the metadata is there, and let the two api calls wait.
This triggered a few places where hypothesis checks for user changed (typically you login inside the client) which will not be the case for us, as we use the session from the user logged in.