### PR TITLE
G20-532 attempt removing special metadata handling for pdf

### DIFF
--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -119,10 +119,7 @@ module.exports = class Guest extends Delegator
 
   # Get the document info
   getDocumentInfo: ->
-    if @plugins.PDF?
-      metadataPromise = Promise.resolve(@plugins.PDF.getMetadata())
-      uriPromise = Promise.resolve(@plugins.PDF.uri())
-    else if @plugins.Document?
+    if @plugins.Document?
       uriPromise = Promise.resolve(@plugins.Document.uri())
       metadataPromise = Promise.resolve(@plugins.Document.metadata)
     else


### PR DESCRIPTION
Remove special handling of metadata when in pdf mode. Grab the metadata from html head as for questions