### PR TITLE
IA1-4328: annotating interaction elements (hypothesis)

### DIFF
--- a/src/annotator/config/index.js
+++ b/src/annotator/config/index.js
@@ -52,5 +52,6 @@ export default function configFrom(window_) {
     removeOnClick: settings.hostPageSetting('removeOnClick'),
     onAnnotationAdded: settings.hostPageSetting('onAnnotationAdded'),
     refreshAnnotations: settings.hostPageSetting('refreshAnnotations'),
+    onAnnotationClick: settings.hostPageSetting('onAnnotationClick'),
   };
 }

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -587,7 +587,7 @@ module.exports = class Guest extends Delegator
     if $(event.currentTarget).data('annotation')
       selector = $(event.currentTarget).data('annotation').target[0].selector
 
-    if selector
+    if selector && this.config.onAnnotationClick
       this.config.onAnnotationClick(selector)
       setTimeout (->
         self.highlightSelected(selector)

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -303,7 +303,7 @@ module.exports = class Guest extends Delegator
       return animationPromise ->
         range = xpathRange.sniff(anchor.range)
         normedRange = range.normalize(root)
-        highlights = highlighter.highlightRange(normedRange)
+        highlights = highlighter.highlightRange(normedRange, self.config.adderRange?.exclude)
 
         $(highlights).data('annotation', anchor.annotation)
         anchor.highlights = highlights

--- a/src/annotator/highlighter.js
+++ b/src/annotator/highlighter.js
@@ -157,10 +157,11 @@ function drawHighlightsAbovePdfCanvas(highlightEl) {
  * element of the specified class and returns the highlight Elements.
  *
  * @param {NormalizedRange} normedRange - Range to be highlighted.
+ * @param {[]} exclude - selectors to exclude from higlighting
  * @param {string} cssClass - A CSS class to use for the highlight
  * @return {HighlightElement[]} - Elements wrapping text in `normedRange` to add a highlight effect
  */
-export function highlightRange(normedRange, cssClass = 'hypothesis-highlight') {
+export function highlightRange(normedRange, exclude = [], cssClass = 'hypothesis-highlight') {
   const white = /^\s*$/;
 
   // Find text nodes within the range to highlight.
@@ -196,7 +197,7 @@ export function highlightRange(normedRange, cssClass = 'hypothesis-highlight') {
   // subset of nodes such as table rows and lists.
   textNodeSpans = textNodeSpans.filter(span =>
     // Check for at least one text node with non-space content.
-    span.some(node => !white.test(node.nodeValue))
+    (exclude.every(item => !span[0].parentNode.closest(item)) && span.some(node => !white.test(node.nodeValue)))
   );
 
   // Wrap each text node span with a `<hypothesis-highlight>` element.

--- a/src/annotator/highlighter.js
+++ b/src/annotator/highlighter.js
@@ -161,7 +161,11 @@ function drawHighlightsAbovePdfCanvas(highlightEl) {
  * @param {string} cssClass - A CSS class to use for the highlight
  * @return {HighlightElement[]} - Elements wrapping text in `normedRange` to add a highlight effect
  */
-export function highlightRange(normedRange, exclude = [], cssClass = 'hypothesis-highlight') {
+export function highlightRange(
+  normedRange,
+  exclude = [],
+  cssClass = 'hypothesis-highlight'
+) {
   const white = /^\s*$/;
 
   // Find text nodes within the range to highlight.
@@ -195,9 +199,11 @@ export function highlightRange(normedRange, exclude = [], cssClass = 'hypothesis
   // Filter out text node spans that consist only of white space. This avoids
   // inserting highlight elements in places that can only contain a restricted
   // subset of nodes such as table rows and lists.
-  textNodeSpans = textNodeSpans.filter(span =>
-    // Check for at least one text node with non-space content and parents are not excluded
-    (exclude.every(item => !span[0].parentNode.closest(item)) && span.some(node => !white.test(node.nodeValue)))
+  textNodeSpans = textNodeSpans.filter(
+    span =>
+      // Check for at least one text node with non-space content and parents are not excluded
+      exclude.every(item => !span[0].parentNode.closest(item)) &&
+      span.some(node => !white.test(node.nodeValue))
   );
 
   // Wrap each text node span with a `<hypothesis-highlight>` element.


### PR DESCRIPTION
player - https://github.com/inspera/test-player/pull/2240

When TT highlight some areas and intersects the math input field, every element inside the field becomes highlighted:
![image](https://user-images.githubusercontent.com/3746371/97981339-ccbdd100-1dda-11eb-94f5-eea2e437015e.png)
First, it looks awful.
Second, it prevents some math element clicking

So to exclude all math elements from highligting I use the existing `exclude` parameter that [comes from player](https://github.com/inspera/test-player/pull/2240/files#diff-f041f0090b3d730fcd97d6be352318e0e0cf71efcafafd0d73e9d4bd72cb3e7aR155)