### PR TITLE
IA1-4655: init and refresh performace improvements

### DIFF
--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -36,8 +36,9 @@ IGNORE_SELECTOR = '[class^="annotator-"],[class^="hypothesis-"]'
 module.exports = class Guest extends Delegator
   SHOW_HIGHLIGHTS_CLASS = 'hypothesis-highlights-always-on'
   EVENT_HYPOTHESIS_INIT = 'Hypothesis:init'
-  EVENT_HYPOTHESIS_ANNOTATION_REMOVED = 'Hypothesis:annotationRemoved'
+  EVENT_HYPOTHESIS_PATH_CHANGE = 'Hypothesis:pathChange'
   EVENT_HYPOTHESIS_DESTROY = 'Hypothesis:destroy'
+  EVENT_HYPOTHESIS_ANNOTATION_REMOVED = 'Hypothesis:annotationRemoved'
   EVENT_HYPOTHESIS_FOCUS_ANNOTATION = 'Hypothesis:focusAnnotation'
 
   # Events to be bound on Delegator#element.
@@ -100,7 +101,7 @@ module.exports = class Guest extends Delegator
   init: () ->
     if this.active
       # just refresh annotations if the lib is already active
-      this._refreshAnnotations()
+      # this._refreshAnnotations()
       return
 
     super
@@ -232,8 +233,9 @@ module.exports = class Guest extends Delegator
 
   _addPlayerListener: ->
     window.addEventListener EVENT_HYPOTHESIS_ANNOTATION_REMOVED, this._refreshAnnotations.bind(this)
-    window.addEventListener EVENT_HYPOTHESIS_DESTROY, this.destroy.bind(this)
     window.addEventListener EVENT_HYPOTHESIS_INIT, this.init.bind(this)
+    window.addEventListener EVENT_HYPOTHESIS_DESTROY, this.destroy.bind(this)
+    window.addEventListener EVENT_HYPOTHESIS_PATH_CHANGE, this._refreshAnnotations.bind(this)
     window.addEventListener EVENT_HYPOTHESIS_FOCUS_ANNOTATION, this.scrollAndHighlightAnnotation.bind(this)
 
   _refreshAnnotations: ->

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -103,9 +103,8 @@ module.exports = class Guest extends Delegator
     this.toggleHighlightClass(event.detail.visibility)
 
   init: () ->
+    # prevent reinit if it's not needed
     if this.active
-      # just refresh annotations if the lib is already active
-      # this._refreshAnnotations()
       return
 
     super
@@ -244,6 +243,7 @@ module.exports = class Guest extends Delegator
     window.addEventListener EVENT_HYPOTHESIS_SET_VISIBILITY, this.setAnnotationsVisibility.bind(this)
 
   _refreshAnnotations: ->
+    # do not load annotations if hypothesis is destroyed
     return if !this.active
 
     this._clearHighlighting()
@@ -269,7 +269,6 @@ module.exports = class Guest extends Delegator
     @element.data('annotator', null)
 
   destroy: ->
-    this.active = false
     $('#annotator-dynamic-style').remove()
 
     this.selections.unsubscribe()
@@ -281,6 +280,7 @@ module.exports = class Guest extends Delegator
       @plugins[name].destroy()
 
     super
+    this.active = false
 
   anchor: (annotation) ->
     self = this

--- a/src/annotator/guest.coffee
+++ b/src/annotator/guest.coffee
@@ -244,6 +244,8 @@ module.exports = class Guest extends Delegator
     window.addEventListener EVENT_HYPOTHESIS_SET_VISIBILITY, this.setAnnotationsVisibility.bind(this)
 
   _refreshAnnotations: ->
+    return if !this.active
+
     this._clearHighlighting()
 
     initialAnnotations = this.config.refreshAnnotations && this.config.refreshAnnotations() || []
@@ -267,6 +269,7 @@ module.exports = class Guest extends Delegator
     @element.data('annotator', null)
 
   destroy: ->
+    this.active = false
     $('#annotator-dynamic-style').remove()
 
     this.selections.unsubscribe()
@@ -278,7 +281,6 @@ module.exports = class Guest extends Delegator
       @plugins[name].destroy()
 
     super
-    this.active = false
 
   anchor: (annotation) ->
     self = this

--- a/src/styles/annotator/adder.scss
+++ b/src/styles/annotator/adder.scss
@@ -20,7 +20,7 @@ $adder-transition-duration: 80ms;
   direction: ltr;
   position: absolute;
   background: var.$white;
-  border: 1px solid rgba(0, 0, 0, 0.2);
+  border: 1px solid var.$grey-5;
   border-radius: 4px;
   box-shadow: 0px 2px 10px 0px rgba(0, 0, 0, 0.25);
 
@@ -62,8 +62,8 @@ $adder-transition-duration: 80ms;
 @mixin adder-arrow($rotation) {
   transform: rotate($rotation);
   background: var.$white;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.2);
-  border-right: 1px solid rgba(0, 0, 0, 0.2);
+  border-bottom: 1px solid var.$grey-5;
+  border-right: 1px solid var.$grey-5;
   content: '';
   display: block;
   height: 6px;


### PR DESCRIPTION
Improvments:
- split `init` and `pathChange` handlers to init and load annotations more accurate
- do not init the librri if it's already active
- do not load annotations if the library is destroyed